### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/detekt-analysis.yml
+++ b/.github/workflows/detekt-analysis.yml
@@ -12,6 +12,10 @@
 # environment variable.
 name: Scan with Detekt
 
+permissions:
+  contents: read
+  security-events: write
+
 on:
   # Triggers the workflow on push or pull request events but only for default and protected branches
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/erikzielke/GoToProject/security/code-scanning/6](https://github.com/erikzielke/GoToProject/security/code-scanning/6)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the least privileges required for the workflow to function correctly. Based on the workflow's actions, the following permissions are needed:
- `contents: read` for checking out the repository and accessing files.
- `security-events: write` for uploading SARIF files.

The `permissions` block can be added at the root level of the workflow to apply to all jobs, or specifically to the `scan` job. In this case, adding it at the root level is more concise and ensures consistency across all jobs.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
