### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,6 +1,8 @@
 # This is a basic workflow that is manually triggered
 
 name: Publish plugin
+permissions:
+  contents: read
 
 # Controls when the action will run. Workflow runs when manually triggered using the UI
 # or API.


### PR DESCRIPTION
Potential fix for [https://github.com/erikzielke/GoToProject/security/code-scanning/4](https://github.com/erikzielke/GoToProject/security/code-scanning/4)

To fix the issue, we will add a `permissions` block to the workflow. This block will specify the minimal permissions required for the workflow to function correctly. Based on the provided workflow, it appears that the workflow primarily interacts with repository contents and does not require extensive write permissions. Therefore, we will set `contents: read` at the root level of the workflow to apply to all jobs. If specific jobs require additional permissions, they can override this setting.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
